### PR TITLE
Fixed Dr.Mourtos profile and minor changes on bin/update

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -18,11 +18,11 @@ chmod 2775 $BASE/new
 pelican content/ --output=$BASE/new
 
 #Sanity check
-test $(stat -c %s $BASE/current/category/members.html) -gt 20000 || { echo "[Error] File $BASE/current/category/members.html appears truncated, please check members file and update again!"; exit 1; }
-test $(stat -c %s $BASE/current/category/software.html) -gt 7000 || { echo "[Error] File $BASE/current/category/software.html appears truncated, please check software file and update again!"; exit 1; }
-test $(stat -c %s $BASE/current/category/projects.html) -gt 10000 || { echo "[Error] File $BASE/current/category/projects.html appears truncated, please check projects file and update again!"; exit 1; }
-test $(stat -c %s $BASE/current/category/alumni.html) -gt 5000 || { echo "[Error] File $BASE/current/category/alumni.html appears truncated, please check alumni file and update again!"; exit 1; }
-test $(stat -c %s $BASE/current/category/yearly-reports.html) -gt 5000 || { echo "[Error] File $BASE/current/category/yearly-reports.html appears truncated, please check yearly-reports file and update again!"; exit 1; }
+test $(stat -c %s $BASE/new/category/members.html) -gt 20000 || { echo "[Error] File $BASE/new/category/members.html appears truncated, please check members file and update again!"; exit 1; }
+test $(stat -c %s $BASE/new/category/software.html) -gt 7000 || { echo "[Error] File $BASE/new/category/software.html appears truncated, please check software file and update again!"; exit 1; }
+test $(stat -c %s $BASE/new/category/projects.html) -gt 10000 || { echo "[Error] File $BASE/new/category/projects.html appears truncated, please check projects file and update again!"; exit 1; }
+test $(stat -c %s $BASE/new/category/alumni.html) -gt 5000 || { echo "[Error] File $BASE/new/category/alumni.html appears truncated, please check alumni file and update again!"; exit 1; }
+test $(stat -c %s $BASE/new/category/yearly-reports.html) -gt 5000 || { echo "[Error] File $BASE/new/category/yearly-reports.html appears truncated, please check yearly-reports file and update again!"; exit 1; }
 
 test -d $BASE/current && mv $BASE/current $BASE/old
 mv $BASE/new $BASE/current

--- a/content/members/mourtos.md
+++ b/content/members/mourtos.md
@@ -2,9 +2,9 @@ title: Ioannis -- Mourtos
 date: 20171020
 joined_date: 20171020
 category: members
-id: mourtos
-givenname: Yiannis-Γιάννης
-surname: Mourtos-Μούρτος
+id: m_mourtos
+givenname: Yiannis
+surname: Mourtos
 memb_title: Dr.
 email: mourtos@aueb.gr
 web_site: https://www.aueb.gr/en/faculty_page/mourtos-ioannis
@@ -15,8 +15,8 @@ postal_address: Patision 76, GR-104 34 Athens, Greece
 photo: imourtos.jpg
 web_log: https://scholar.google.gr/citations?user=0d5lliEAAAAJ&hl=el
 github: mourtos
-twitter: @Yiannis_Mourtos
-linkedin: https://www.linkedin.com/in/yiannis-mourtos-73a1ab2a/
+twitter: Yiannis_Mourtos
+linkedin: yiannis-mourtos-73a1ab2a
 
 **Yiannis Mourtos** is an Associate Professor in "Mathematics of Operations Research" at the Department of Management Science & Technology, Athens University of Economics and Business. He studied Computer Engineering and Informatics at the corresponding department of the University of Patras and obtained both his MSc and PhD from the Operational Research Department, London School of Economics and Political Science. He has worked as a Lecturer at the Department of Economics, University of Patras.
 

--- a/content/pubs.bib
+++ b/content/pubs.bib
@@ -5532,150 +5532,148 @@ Specialist Group},
     XEcategory = "Conference Publications",
 }
 
-@Article{AGA1,
+﻿@Article{AGA1,
 	Title="Extract purchasing patterns for a focal product category using sales data: The case of skincare products (in Greek)",
 	Author="Kalaidopoulou K. and Griva A.",
 	Journal="Astrolavos Journal of new Technologies",
 	Volume="25",
 	Pages="3-18",
-	Month="Optional",
 	Year="2016",
 	XEmember="m_griva",
 	XEcategory= "Journal Articles"
 }
 
-@proceedings{AGP1,
+@InProceedings{AGP1,
 	Title="Identifying customer satisfaction patterns via data mining: The case of Greek e-shops",
 	Author="Kalaidopoulou K. and Triantafyllou S. and Griva A. and Pramatari K.",
 	Location="Genova, Italy",
 	Month="4-5 September",
 	Year="2017",
-	Organization=" Proceedings of the 11th Mediterranean Conference on Information Systems (MCIS 2017)",
+	Booktitle =" Proceedings of the 11th Mediterranean Conference on Information Systems (MCIS 2017)",
 	XEmember="m_griva",
 	XEcategory= "Conference Publications"
 }
 
-@Proceedings{AGP2,
+@InProceedings{AGP2,
 	Title="Enhance shopping experience and support decision making leveraging BLE beacons in a grocery retail store ",
 	Author="Triantafyllou S. and Koutsokera L. and Stavrou V. and Griva A.",
 	Location="Athens, Greece",
 	Month=" March",
 	Year="2017",
-	Organization="Proceedings of 14th Student Conference of Management Science and Technology",
+	Booktitle ="Proceedings of 14th Student Conference of Management Science and Technology",
 	XEmember="m_griva",
 	XEcategory= "Conference Publications"
 }
 
-@Proceedings{AGP3,
+@InProceedings{AGP3,
 	Title="Customer Visit Segmentation Using Market Basket Data",
 	Author="Griva A. and Bardaki C. and Pramatari Κ.",
 	Location="Dublin, Ireland",
 	Month="11-14 December",
 	Year="2016",
-	Organization="Proceedings of pre-International Conference on Information Systems (pre-ICIS 2016), Special Interest Group on Decision Support and Analytics (SIGDSA)/ IFIP WG8.3 symposium: Innovations in Data Analytics",
+	Booktitle ="Proceedings of pre-International Conference on Information Systems (pre-ICIS 2016), Special Interest Group on Decision Support and Analytics (SIGDSA)/ IFIP WG8.3 symposium: Innovations in Data Analytics",
 	XEmember="m_griva",
 	XEcategory= "Conference Publications",
 	Note="(Best Paper Award)"
 }
 
-@Proceedings{AGP4,
+@InProceedings{AGP4,
 	Title="Identifying complex and multi-step customer projects: A graph mining market basket approach",
 	Author="Sarantopoulos P. and Griva A. and Papakyriakopoulos D. and Giovanis A.",
 	Location="Manchester, United Kingdom",
 	Month="28 September",
 	Year="2016",
-	Organization="Proceeding of AMBS Big Data Forum ", 
+	Booktitle ="Proceeding of AMBS Big Data Forum ", 
 	XEmember="m_griva",
 	XEcategory= "Conference Publications"
 }
 
-@Proceedings{AGP5,
+@InProceedings{AGP5,
 	Title="Mapping moving object events into object network flows to support decisions",
 	Author="Griva A. and Bardaki C. and Pramatari Κ. and Doukidis G.",
 	Location="Istanbul, Turkey",
 	Month="15 June",
 	Year="2016",
-	Organization="Proceedings of 24th European Conference on Information Systems (ECIS 2016)", 
+	Booktitle ="Proceedings of 24th European Conference on Information Systems (ECIS 2016)", 
 	XEmember="m_griva",
 	XEcategory= "Conference Publications"
 }
 
-@Proceedings{AGP6,
+@InProceedings{AGP6,
 	Title="Segmentation of Shopper Visits based on Shopper Interaction data in Different Retail Contexts",
 	Author="Griva A. and Bardaki C. and Pramatari Κ. and Doukidis G.", 
 	Location="Munich, Germany",
 	Month="3-5 June",
 	Year="2016",
-	Organization="1st EURO Working Group on Retail Operations",
+	Booktitle ="1st EURO Working Group on Retail Operations",
 	XEmember="m_griva",
 	XEcategory= "Conference Publications"
 }
 
-@Proceedings{AGP7,
+@InProceedings{AGP7,
 	Title="How shoppers buy a specific product category in retail stores? The case of face care products",
 	Author="Kalaidopoulou K. and Griva A. and Sarantopoulos P.", 
 	Location="Athens, Greece ",
 	Month="12 May",
 	Year="2016",
-	Organization="Proceedings of 13th Student Conference of Management Science and Technology",
-XEmember="m_griva",
+	Booktitle ="Proceedings of 13th Student Conference of Management Science and Technology",
+	XEmember="m_griva",
 	XEcategory= "Conference Publications"
 }
 
-@Proceedings{AGP8,
+@InProceedings{AGP8,
 	Title="Investigating shopping visits patterns across different store types: The case of a grocery retail chain",
 	Author="Kalaidopoulou K. and Koutsokera L. and Stavrou V. and Griva A.", 
 	Location="Athens, Greece ",
 	Month="12 May",
 	Year="2016",
-	Organization="Proceedings of 13th Student Conference of Management Science and Technology",
+	Booktitle ="Proceedings of 13th Student Conference of Management Science and Technology",
 	XEmember="m_griva",
 	XEcategory= "Conference Publications"
 }
 
-@Proceedings{AGP9,
+@InProceedings{AGP9,
 	Title="RFID-Enabled Visualization of Product Flows: A Data Analytics Approach",
 	Author=" Griva A. and Bardaki C. and Pramatari Κ.",
-	
 	Location="Samos, Greece ",
 	Month="October 3-5",
 	Year="2015",
-	Organization="Proceedings of 9th Mediterranean Conference on Information Systems (MCIS 2015)", 
-XEmember="m_griva",
+	Booktitle ="Proceedings of 9th Mediterranean Conference on Information Systems (MCIS 2015)", 
+	XEmember="m_griva",
 	XEcategory= "Conference Publications"
 }
 
-@Proceedings{AGP10,
+@InProceedings{AGP10,
 	Title="Shopping Goals Detection: Mining POS data from a Do-it-Yourself (DIY) retailer",
 	Author ="Griva A. and Bardaki C. and Papakyriakopoulos D.",
 	Location="Athens, Greece",
 	Month="14 May",
 	Year="2015",
-	Organization="Proceedings of 12th Student Conference of Management Science and Technology", 
-XEmember="m_griva",
+	Booktitle ="Proceedings of 12th Student Conference of Management Science and Technology", 
+	XEmember="m_griva",
 	XEcategory= "Conference Publications"
 }
 
-@Proceedings{AGP11,
+@InProceedings{AGP11,
 	Title="Identification of Customer Segments via Data Mining",
 	Author="Kalaidopoulou K. and Kanellopoulos I. and Griva A.",
 	Location="Athens, Greece",
 	Month="14 May",
 	Year="2015",
-	Organization="Proceedings of 12th Student Conference of Management Science and Technology", 
-XEmember="m_griva",
+	Booktitle ="Proceedings of 12th Student Conference of Management Science and Technology", 
+	XEmember="m_griva",
 	XEcategory= "Conference Publications"
 }
 
-@Proceedings{AGP12,
+@InProceedings{AGP12,
 	Title="A Data Mining-based Framework to Identify Shopping Missions",
 	Author="Griva A. and Bardaki C. and Sarantopoulos P. and Papakyriakopoulos D.", 
 	Location="Verona, Italy",
 	Month="September 3-5",
 	Year="2014",
-XEmember="m_griva",
+	XEmember="m_griva",
 	XEcategory= "Conference Publications",
-	Organization="Proceedings of 8th Mediterranean Conference on Information Systems (MCIS 2014)"
+	Booktitle ="Proceedings of 8th Mediterranean Conference on Information Systems (MCIS 2014)"
 }
 
 @article{ ISI:000399023600001,


### PR DESCRIPTION
Fixed Dr.Mourtos profile info, the **m_moutros** tag was missing and pelican couldn't relate his publications to his profile.

In addition, the update script sanity test was checking the balab's current directory files which is a mistake. 
When a pelican updates it creates a **new** named directory, therefore, there is no meaning to check the **current** instead of the **new**.