### PR TITLE
Correct syntax error in publications

### DIFF
--- a/content/pubs.bib
+++ b/content/pubs.bib
@@ -8,7 +8,7 @@
 	XEdoi = "https://doi.org/10.1016/j.jss.2017.12.034",
 	XEurl = "http://www.sciencedirect.com/science/article/pii/S0164121217303114",
 	author = "Tushar Sharma and Diomidis Spinellis",
-	keywords = "Code smells, Software smells, Antipatterns, Software quality, Maintainability, Smell detection tools, Technical debt"
+	keywords = "Code smells, Software smells, Antipatterns, Software quality, Maintainability, Smell detection tools, Technical debt",
 	XEmember="m_tushar m_dds",
 	XEcategory = "Journal Articles",
 }


### PR DESCRIPTION
Publications are not displayed in the website because of a missing comma in pubs.bib. With this correction they show up correctly on my local machine.