### PR TITLE
Exit with code 1 to make the CI test fail after a parsing failure

### DIFF
--- a/content/pubs.bib
+++ b/content/pubs.bib
@@ -8,7 +8,7 @@
 	XEdoi = "https://doi.org/10.1016/j.jss.2017.12.034",
 	XEurl = "http://www.sciencedirect.com/science/article/pii/S0164121217303114",
 	author = "Tushar Sharma and Diomidis Spinellis",
-	keywords = "Code smells, Software smells, Antipatterns, Software quality, Maintainability, Smell detection tools, Technical debt"
+	keywords = "Code smells, Software smells, Antipatterns, Software quality, Maintainability, Smell detection tools, Technical debt",
 	XEmember="m_tushar m_dds",
 	XEcategory = "Journal Articles",
 }

--- a/content/pubs.bib
+++ b/content/pubs.bib
@@ -8,7 +8,7 @@
 	XEdoi = "https://doi.org/10.1016/j.jss.2017.12.034",
 	XEurl = "http://www.sciencedirect.com/science/article/pii/S0164121217303114",
 	author = "Tushar Sharma and Diomidis Spinellis",
-	keywords = "Code smells, Software smells, Antipatterns, Software quality, Maintainability, Smell detection tools, Technical debt",
+	keywords = "Code smells, Software smells, Antipatterns, Software quality, Maintainability, Smell detection tools, Technical debt"
 	XEmember="m_tushar m_dds",
 	XEcategory = "Journal Articles",
 }

--- a/plugins/pelican-bibtex/pelican_bibtex.py
+++ b/plugins/pelican-bibtex/pelican_bibtex.py
@@ -57,6 +57,7 @@ def add_publications(generator):
         logger.error('`pelican_bibtex` failed to parse file %s: %s' % (
             refs_file,
             str(e)))
+        exit(1)
         return
 
     publications = []

--- a/plugins/pelican-bibtex/pelican_bibtex.py
+++ b/plugins/pelican-bibtex/pelican_bibtex.py
@@ -54,7 +54,7 @@ def add_publications(generator):
     try:
         bibdata_all = Parser().parse_file(refs_file)
     except PybtexError as e:
-        logger.warn('`pelican_bibtex` failed to parse file %s: %s' % (
+        logger.error('`pelican_bibtex` failed to parse file %s: %s' % (
             refs_file,
             str(e)))
         return


### PR DESCRIPTION
Example of failure with wrong syntax in .bib file: https://travis-ci.org/AUEB-BALab/web/builds/327620599
Passing test after reverting the wrong syntax: https://travis-ci.org/AUEB-BALab/web/builds/327621716