### PR TITLE
Ignore output & balab folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 pelicanconf.pyc
+balab/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 pelicanconf.pyc
 balab/
+output/


### PR DESCRIPTION
When testing locally:
- sh bin/update creates a folder called balab
- pelican content creates a folder called output

It seems to me that these two folders don't have a reason to be in version control so I have added them to the .gitignore file to avoid commits by mistake in the future.