### PR TITLE
CI troubleshooting related to JINJA_ENVIRONMENT

### DIFF
--- a/content/pubs.bib
+++ b/content/pubs.bib
@@ -59,7 +59,6 @@
 	XEurl="https://www.computer.org/csdl/mags/so/2016/02/mso2016020004.pdf",
 	XEmember="m_dds",
 	XEcategory = "Journal Articles",
-	ISSN={0740-7459}
 }
 
 @article{Spi16f,
@@ -78,7 +77,6 @@
 	XEurl="https://www.computer.org/csdl/mags/so/2016/03/mso2016030004.pdf",
 	XEmember="m_dds",
 	XEcategory = "Journal Articles",
-	ISSN={0740-7459}
 }
 
 @Article{Spi16g,
@@ -2811,7 +2809,6 @@ Organizational Dynamic Behaviour},
 	XEurl="http://www.computer.org/csdl/mags/so/2016/01/mso2016010003.pdf",
 	XEmember="m_dds",
 	XEcategory = "Journal Articles",
-	ISSN={0740-7459}
 }
 @article{Spi15j,
 	author={Diomidis Spinellis},
@@ -2828,7 +2825,6 @@ Organizational Dynamic Behaviour},
 	XEurl="https://www.computer.org/csdl/mags/so/2015/06/mso2015060004.pdf",
 	XEmember="m_dds",
 	XEcategory = "Journal Articles",
-	ISSN={0740-7459}
 }
 
 @Article{EH11,
@@ -3847,7 +3843,6 @@ Databases},
 	title="Ptrim: {A} {M}arket-{B}ased {A}pproach to {M}anaging the {R}isk of {P}eer-{T}o-{P}eer",
 	author="Stephanos Androutsellis-Theotokis and Diomidis Spinellis",
 	booktitle="Proceedings of the Fifth International Workshop on Databases, Information Systems and Peer-to-Peer Computing (DBISP2P 2007), in conjunction with VLDB2007, Springer Lecture Notes in Computer Science",
-	location="Montreal, Canada",
 	month=sep,
 	day="24",
 	year=2007,
@@ -5373,7 +5368,6 @@ Specialist Group},
 	journal  = "XRDS: Crossroads, The ACM Magazine for Students",
 	year     = "2013",
   	volume    =  "20",
-		XEcategory = "Magazine Articles",
 	number	= "2",
 	pages= {15--16},
 	XEurl="http://xrds.acm.org/blog/2013/07/security-bugs-in-large-software-ecosystems/",

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 from datetime import datetime
 
-JINJA_EXTENSIONS = ['jinja2.ext.loopcontrols']
+JINJA_ENVIRONMENT = {'extensions': ['jinja2.ext.loopcontrols']}
 
 AUTHOR = 'Efstathia Chioteli, Ioannis Batas'
 SITENAME = 'BALab'

--- a/publishconf.py
+++ b/publishconf.py
@@ -14,7 +14,7 @@ SITEURL = ''
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'
-CATEGORY_FEED_ATOM = 'feeds/%s.atom.xml'
+CATEGORY_FEED_ATOM = 'feeds/{slug}.atom.xml'
 
 DELETE_OUTPUT_DIRECTORY = True
 


### PR DESCRIPTION
Solving KeyError: u'JINJA_ENVIRONMENT':
- Identifying that problem is related with upgrade from pelican 3.7.1 to 4.0.1 and understanding the differences between two versions
- Solving the core problem - Replacing JINJA_EXTENSIONS with JINJA_ENVIRONMENT:  "JINJA_EXTENSIONS has been replaced by the JINJA_ENVIRONMENT setting" and isn't supported anymore
- Replacing %s to {slug}, according to new version: "All settings for slugs now use {slug} and/or {lang} rather than %s"